### PR TITLE
Make ImprovDevice name nullable [breaking change]

### DIFF
--- a/app/src/main/java/com/wifi/improv/demo/MainActivity.kt
+++ b/app/src/main/java/com/wifi/improv/demo/MainActivity.kt
@@ -165,7 +165,7 @@ fun ImprovDeviceList(
                 onClick = { connect(it) }
             ) {
                 Column {
-                    Text(it.name)
+                    Text(it.name ?: it.address)
                     Text(
                         text = it.address,
                         style = MaterialTheme.typography.caption

--- a/library/src/main/java/com/wifi/improv/ImprovDevice.kt
+++ b/library/src/main/java/com/wifi/improv/ImprovDevice.kt
@@ -1,7 +1,7 @@
 package com.wifi.improv
 
 data class ImprovDevice(
-    val name: String,
+    val name: String?,
     val address: String
 ) {
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
Make the name of `ImprovDevice`s nullable to fix the following crash that may occur:

```
FATAL EXCEPTION: main
java.lang.NullPointerException: name must not be null
	at com.wifi.improv.ImprovManager$scanCallback$1.onScanResult(ImprovManager.kt:46)
	at android.bluetooth.le.BluetoothLeScanner$BleScanCallbackWrapper$1.run(BluetoothLeScanner.java:568)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8592)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
```

The library already acknowledge that it may be null internally:

https://github.com/improv-wifi/sdk-android/blob/9def544f72a087dadb742c535afd487013491dc7/library/src/main/java/com/wifi/improv/ImprovManager.kt#L44