### PR TITLE
Add RPC Result characteristic

### DIFF
--- a/app/src/main/java/com/wifi/improv/demo/ImprovViewModel.kt
+++ b/app/src/main/java/com/wifi/improv/demo/ImprovViewModel.kt
@@ -21,6 +21,7 @@ class ImprovViewModel : ViewModel(), ImprovManagerCallback {
     var connectedDevice: ImprovDevice? = null
     var deviceState: DeviceState? = null
     var errorState: ErrorState? = null
+    var rpcResult = listOf<String>()
 
     private fun update() {
         viewModelScope.launch {
@@ -31,7 +32,8 @@ class ImprovViewModel : ViewModel(), ImprovManagerCallback {
                 connectedDevice?.address ?: "",
                 connectedDevice != null,
                 deviceState.toString(),
-                errorState.toString()
+                errorState.toString(),
+                rpcResult
             )
         }
     }
@@ -64,6 +66,11 @@ class ImprovViewModel : ViewModel(), ImprovManagerCallback {
         this.errorState = errorState
         update()
     }
+
+    override fun onRpcResult(result: List<String>) {
+        this.rpcResult = result
+        update()
+    }
 }
 
 @Immutable
@@ -74,5 +81,6 @@ data class ImprovScreenState(
     val address: String,
     val btConnected: Boolean,
     val deviceState: String,
-    val errorState: String
+    val errorState: String,
+    val rpcResult: List<String>
 )

--- a/app/src/main/java/com/wifi/improv/demo/MainActivity.kt
+++ b/app/src/main/java/com/wifi/improv/demo/MainActivity.kt
@@ -114,7 +114,8 @@ fun ImprovMain(
                         name = screenState.name,
                         address = screenState.address,
                         deviceState = screenState.deviceState,
-                        errorState = screenState.errorState
+                        errorState = screenState.errorState,
+                        rpcResult = screenState.rpcResult
                     )
                     Spacer(Modifier.padding(5.dp))
                 }
@@ -132,7 +133,8 @@ fun ImprovStatus(
     name: String?,
     address: String?,
     deviceState: String?,
-    errorState: String?
+    errorState: String?,
+    rpcResult: List<String>
 ) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column {
@@ -144,6 +146,7 @@ fun ImprovStatus(
             Text(text = "Address: $address")
             Text(text = "Device State: $deviceState")
             Text(text = "Error State: $errorState")
+            Text(text = "RPC Result: $rpcResult")
         }
     }
 }
@@ -220,7 +223,8 @@ fun DefaultPreview() {
         "12:34:56:78",
         true,
         DeviceState.AUTHORIZED.toString(),
-        "errorState"
+        "errorState",
+        listOf()
     )
     ImprovMain(screenState = improvScreenState, {}, {}, {}, { _, _ -> })
 }

--- a/library/src/main/java/com/wifi/improv/BluetoothOperations.kt
+++ b/library/src/main/java/com/wifi/improv/BluetoothOperations.kt
@@ -9,6 +9,9 @@ sealed class BleOperationType
 data class Connect(val device: BluetoothDevice) : BleOperationType()
 data class Disconnect(val device: BluetoothDevice) : BleOperationType()
 
+object DiscoverServices: BleOperationType()
+object RequestLargeMtu: BleOperationType()
+
 data class CharacteristicRead(val char: BluetoothGattCharacteristic) : BleOperationType()
 data class CharacteristicWrite(val char: BluetoothGattCharacteristic) : BleOperationType()
 

--- a/library/src/main/java/com/wifi/improv/ImprovManager.kt
+++ b/library/src/main/java/com/wifi/improv/ImprovManager.kt
@@ -94,7 +94,7 @@ class ImprovManager(
                     val value =
                         characteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT8, 0).toUByte()
                     Log.i(TAG, "Current State has changed to $value.")
-                    val deviceState = DeviceState.entries.firstOrNull { it.value == value }
+                    val deviceState = DeviceState.values().firstOrNull { it.value == value }
                     if (deviceState != null)
                         callback.onStateChange(deviceState)
                     else
@@ -104,7 +104,7 @@ class ImprovManager(
                     val value =
                         characteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT8, 0).toUByte()
                     Log.i(TAG, "Error State has changed to $value.")
-                    val errorState = ErrorState.entries.firstOrNull { it.value == value }
+                    val errorState = ErrorState.values().firstOrNull { it.value == value }
                     if (errorState != null)
                         callback.onErrorStateChange(errorState)
                     else

--- a/library/src/main/java/com/wifi/improv/ImprovManagerCallback.kt
+++ b/library/src/main/java/com/wifi/improv/ImprovManagerCallback.kt
@@ -11,4 +11,6 @@ interface ImprovManagerCallback {
     fun onStateChange(state: DeviceState)
 
     fun onErrorStateChange(errorState: ErrorState)
+
+    fun onRpcResult(result: List<String>)
 }


### PR DESCRIPTION
 - Add the [RPC Result characteristic](https://www.improv-wifi.com/ble/#:~:text=Characteristic%3A%20RPC%20Result) to the library's callback to allow clients to use it
 - Increase MTU size to ensure the characteristic read is not truncated to the first 20 bytes, as RPC Results will be larger most of the time

Example from demo app:
![Demo app showing RPC Result: [https://my.home-assitant.io/redirect/config_flow_start?domain=esphome, http://192.168.2.16:80]](https://github.com/user-attachments/assets/9e00cc4d-8c94-4bf7-af02-c308acdb1f6c)
