### PR TITLE
Add publishing to Maven Central on release

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -39,3 +39,14 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./app/build/outputs/apk/debug/app-debug.apk
           asset_name: demo.apk
+
+      - name: Publish to Maven Central
+        if: github.event.release.draft == 'false'
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+        env:
+          IMPROV_LIB_RELEASE: ${{ github.event.release.tag_name }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PGP_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_PGP_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PGP_KEY_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ buildscript {
 
 plugins {
     id 'org.jetbrains.kotlin.plugin.compose' version "$kotlin_version" apply false
+    id 'com.vanniktech.maven.publish' version '0.29.0' apply false
 }
 
 task clean(type: Delete) {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,10 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'com.vanniktech.maven.publish'
 }
 
 android {
@@ -27,5 +31,40 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+    }
+}
+
+mavenPublishing {
+    configure(new AndroidSingleVariantLibrary("release", true, true))
+
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+
+    coordinates("org.openhomefoundation.improv-wifi", "sdk-android", "${System.getenv('IMPROV_LIB_RELEASE')}")
+
+    pom {
+        name = "Android SDK for Improv Wi-Fi"
+        description = "Easily detect and connect Improv Wi-Fi devices to the network on Android using BLE"
+        inceptionYear = "2021"
+        url = "https://github.com/improv-wifi/sdk-android"
+        licenses {
+            license {
+                name = "Apache License, Version 2.0"
+                url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        }
+        developers {
+            developer {
+                id = "improv-wifi"
+                name = "Improv Wi-Fi"
+                url = "https://github.com/improv-wifi"
+            }
+        }
+        scm {
+            url = "https://github.com/improv-wifi/sdk-android"
+            connection = "scm:git:git://github.com/improv-wifi/sdk-android.git"
+            developerConnection = "scm:git:ssh://git@github.com/improv-wifi/sdk-android.git"
+        }
     }
 }


### PR DESCRIPTION
Publish the library to Maven Central when creating a new GitHub release.

Test release published by running the command locally: https://central.sonatype.com/artifact/org.openhomefoundation.improv-wifi/sdk-android/0.0.3-alpha02

I've mostly followed the following documentation and guides: https://vanniktech.github.io/gradle-maven-publish-plugin/central/, https://medium.com/proandroiddev/publish-on-maven-central-2716bbaa91be, https://proandroiddev.com/automate-maven-central-publication-16c67d9049a8